### PR TITLE
Fix stripping out value of blank keys

### DIFF
--- a/steamfiles/acf.py
+++ b/steamfiles/acf.py
@@ -19,10 +19,13 @@ def loads(data):
     current_section = parsed
     sections = []
 
-    lines = (line.replace('"', '').strip() for line in data.splitlines())
+    lines = (line.strip() for line in data.splitlines())
+
     for line in lines:
         try:
             key, value = line.split(None, 1)
+            key = key.replace('"', '').lstrip()
+            value = value.replace('"', '').rstrip()
         except ValueError:
             if line == SECTION_START:
                 # Initialize the last added section.
@@ -32,7 +35,7 @@ def loads(data):
                 sections.pop()
             else:
                 # Add a new section to the queue.
-                sections.append(line)
+                sections.append(line.replace('"', ''))
             continue
 
         current_section[key] = value

--- a/tests/test_acf.py
+++ b/tests/test_acf.py
@@ -13,6 +13,12 @@ def acf_data():
 
 
 @pytest.mark.usefixtures('acf_data')
+def test_acf_keys_exist(acf_data):
+    data = acf.loads(acf_data)
+    assert 'BytesDownloaded' in data['AppState']['DlcDownloads']['202988']
+    assert 'BytesToDownload' in data['AppState']['DlcDownloads']['202988']
+
+@pytest.mark.usefixtures('acf_data')
 def test_loads_dumps(acf_data):
     assert acf.dumps(acf.loads(acf_data)) == acf_data
 

--- a/tests/test_data/appmanifest_202970.acf
+++ b/tests/test_data/appmanifest_202970.acf
@@ -17,7 +17,7 @@
 	"UserConfig"
 	{
 		"language"		"russian"
-		"hasBlankValue"	""
+		"hasBlankValue"		""
 	}
 	"MountedDepots"
 	{

--- a/tests/test_data/appmanifest_202970.acf
+++ b/tests/test_data/appmanifest_202970.acf
@@ -17,6 +17,7 @@
 	"UserConfig"
 	{
 		"language"		"russian"
+		"hasBlankValue"	""
 	}
 	"MountedDepots"
 	{


### PR DESCRIPTION
I'm not saying this is the right fix or not, since it "feels a little uglier" but it's definitely technically correct as far as I know. When you have a key with a blank value "",  the parenthesis are removed and the entire line is stripped. It then appears to be the beginning of a section causing the entire file to be parsed incorrectly.

What do you think?