### PR TITLE
Made type error more clear in ACF loading

### DIFF
--- a/steamfiles/acf.py
+++ b/steamfiles/acf.py
@@ -12,7 +12,7 @@ def loads(data, wrapper=dict):
     :return: An Ordered Dictionary with ACF data.
     """
     if not isinstance(data, str):
-        raise TypeError('can only load a str as an ACF')
+        raise TypeError('can only load a str as an ACF but got ' + type(data).__name__)
 
     parsed = wrapper()
     current_section = parsed
@@ -59,7 +59,7 @@ def dumps(obj):
     :return: ACF data.
     """
     if not isinstance(obj, dict):
-        raise TypeError('can only dump a dictionary as an ACF')
+        raise TypeError('can only dump a dictionary as an ACF but got ' + type(obj).__name__)
 
     return '\n'.join(_dumps(obj, level=0)) + '\n'
 

--- a/steamfiles/appinfo.py
+++ b/steamfiles/appinfo.py
@@ -37,7 +37,7 @@ def loads(data, wrapper=dict):
     :return: An Ordered Dictionary with Appinfo data.
     """
     if not isinstance(data, (bytes, bytearray)):
-        raise TypeError('can only load a bytes-like object as an Appinfo')
+        raise TypeError('can only load a bytes-like object as an Appinfo but got ' + type(data).__name__)
 
     return AppinfoDecoder(data, wrapper=wrapper).decode()
 
@@ -58,7 +58,7 @@ def dumps(obj):
     :return:
     """
     if not isinstance(obj, dict):
-        raise TypeError('can only dump a dictionary as an Appinfo')
+        raise TypeError('can only dump a dictionary as an Appinfo but got ' + type(obj).__name__)
 
     return b''.join(AppinfoEncoder(obj).iter_encode())
 
@@ -271,7 +271,7 @@ class AppinfoEncoder:
             elif isinstance(value, Integer):
                 yield from self.encode_integer(key, value)
             else:
-                raise TypeError('Unknown value type')
+                raise TypeError('Unknown value type ' + type(value).__name__)
 
         yield SECTION_END
         if root_section:

--- a/steamfiles/manifest.py
+++ b/steamfiles/manifest.py
@@ -51,7 +51,7 @@ def loads(data, wrapper=dict):
     :return: A dictionary with Manifest data.
     """
     if not isinstance(data, (bytes, bytearray)):
-        raise TypeError('can only load a bytes-like object as a Manifest')
+        raise TypeError('can only load a bytes-like object as a Manifest but got ' + type(data).__name__)
 
     offset = 0
     parsed = wrapper()
@@ -94,7 +94,7 @@ def dumps(obj):
     :return: A file object.
     """
     if not isinstance(obj, dict):
-        raise TypeError('can only dump a dictionary as a Manifest')
+        raise TypeError('can only dump a dictionary as a Manifest but got ' + type(obj).__name__)
 
     data = []
     int32 = struct.Struct('<I')


### PR DESCRIPTION
I was checking my logs and a user ran into this exception but I have no idea why as I'm using Python3 and pass something should be clearly a string.

Since this already throws an exception I feel like it could be slightly more helpful to the user.