### PR TITLE
Add __main__.py

### DIFF
--- a/steamfiles/__main__.py
+++ b/steamfiles/__main__.py
@@ -1,0 +1,29 @@
+from argparse import ArgumentParser
+from pprint import PrettyPrinter
+
+from . import acf, appinfo, manifest
+
+parser = ArgumentParser(
+    prog="steamfiles",
+    description=" Python library for parsing the most common Steam file formats. ",
+)
+parser.add_argument(
+    "type", choices=["acf", "appinfo", "manifest"], help="the type of file"
+)
+parser.add_argument("file", type=str, help="file to parse")
+args = parser.parse_args()
+
+if args.type == "acf":
+    mode = "r"
+    module = acf
+if args.type == "appinfo":
+    mode = "rb"
+    module = appinfo
+if args.type == "manifest":
+    mode = "rb"
+    module = manifest
+
+pp = PrettyPrinter()
+with open(args.file, mode) as f:
+    data = module.load(f)
+    pp.pprint(data)


### PR DESCRIPTION
I needed to inspect some steam files, not from python but from commandline.

This PR adds a `__main__.py` such that the module can be called using

```
python -m steamfiles appinfo path/to/appinfo.vdf
```