### PR TITLE
Fix a possible error with open().read()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io import open
 import os
 import setuptools
 try: # for pip >= 10


### PR DESCRIPTION
I had this little error that broke the installation from pip.

Error :  
```python
Collecting steamfiles
  Using cached https://files.pythonhosted.org/packages/7a/f4/a55dad3536ce0547c87e49d744797bcaa2474a5363ef688576ac60c3d3c2/steamfiles-0.1.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-Bp3_YZ/steamfiles/setup.py", line 26, in <module>
        long_description=read('README.rst'),
      File "/tmp/pip-install-Bp3_YZ/steamfiles/setup.py", line 12, in read
        return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
    TypeError: 'encoding' is an invalid keyword argument for this function
```

This is fixed in this pr