### PR TITLE
(quick fixes) Fixing various issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io import open
 import os
 import setuptools
 # This is not recommanded by the development team. You should change the way you parse requirements

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 import os
 import setuptools
-try: # for pip >= 10
+# This is not recommanded by the development team. You should change the way you parse requirements
+try: # for pip >= 20
     from pip._internal.req import parse_requirements
-    from pip._internal.download import PipSession
+    from pip._internal.network.session import PipSession # this should fix installation problems for pip>=20
 except ImportError: # for pip <= 9.0.3
     from pip.req import parse_requirements
     from pip.download import PipSession


### PR DESCRIPTION
- Fix a possible problem using `open` which can give the following error depending on the Python environnement : 

```python
Collecting steamfiles
  Using cached https://files.pythonhosted.org/packages/7a/f4/a55dad3536ce0547c87e49d744797bcaa2474a5363ef688576ac60c3d3c2/steamfiles-0.1.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-Bp3_YZ/steamfiles/setup.py", line 26, in <module>
        long_description=read('README.rst'),
      File "/tmp/pip-install-Bp3_YZ/steamfiles/setup.py", line 12, in read
        return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
    TypeError: 'encoding' is an invalid keyword argument for this function
```

- Fixed an installation issue cause by the usage of `pip._internal` that shouldn't be used in a production-ready package. Warning, this fix still uses `pip._internal` so this is not very accurate but it does the job

Error before this fix : 
```python
Defaulting to user installation because normal site-packages is not writeable
Processing ./Downloads/steamfiles
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-8kzv1u6x/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-8kzv1u6x/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-req-build-8kzv1u6x/pip-egg-info
         cwd: /tmp/pip-req-build-8kzv1u6x/
    Complete output (12 lines):
    Traceback (most recent call last):
      File "/tmp/pip-req-build-8kzv1u6x/setup.py", line 7, in <module>
        from pip._internal.network import PipSession
    ImportError: cannot import name 'PipSession' from 'pip._internal.network' (/home/gabyfle/.local/lib/python3.7/site-packages/pip/_internal/network/__init__.py)
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-8kzv1u6x/setup.py", line 9, in <module>
        from pip.req import parse_requirements
    ModuleNotFoundError: No module named 'pip.req'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```